### PR TITLE
Fix logs encryption

### DIFF
--- a/MagicalCryptoWallet.Tests/CryptoTests.cs
+++ b/MagicalCryptoWallet.Tests/CryptoTests.cs
@@ -38,8 +38,6 @@ namespace MagicalCryptoWallet.Tests
 			Assert.NotEqual(toEncrypt, encypted);
 			decrypted = StringCipher.Decrypt(encypted, password);
 			Assert.Equal(toEncrypt, decrypted);
-			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, ""));
-			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
 
 			toEncrypt = "foo@éóüö";
 			password = "";
@@ -48,6 +46,33 @@ namespace MagicalCryptoWallet.Tests
 			decrypted = StringCipher.Decrypt(encypted, password);
 			Assert.Equal(toEncrypt, decrypted);
 			Assert.Throws<CryptographicException>(() => StringCipher.Decrypt(encypted, "wrongpassword"));
+		}
+
+		[Fact]
+		public void AuthenticateMessageTest()
+		{
+			var count = 0;
+			var errorCount = 0;
+			while(count < 10000)
+			{
+				var password = "password";
+				var plainText = "juan carlos";
+				var encypted = StringCipher.Encrypt(plainText, password);
+
+				try
+				{
+					// This must fail because the password is wrong
+					var t = StringCipher.Decrypt(encypted, "WRONG-PASSWORD");
+					errorCount++;
+				}
+				catch(CryptographicException ex){
+					Assert.StartsWith("Message Authentication failed", ex.Message);
+				}
+				count++;
+			}
+			var rate = (double)errorCount/(double)count;
+			Assert.True(rate < 0.000001 && rate > -0.000001);
+
 		}
 	}
 }

--- a/MagicalCryptoWallet/Crypto/StringCipher.cs
+++ b/MagicalCryptoWallet/Crypto/StringCipher.cs
@@ -17,40 +17,43 @@ namespace MagicalCryptoWallet.Crypto
 		// This constant determines the number of iterations for the password bytes generation function.
 		private const int DerivationIterations = 1000;
 
+		private static AesManaged CreateAES()
+		{
+			var aes = new AesManaged();
+			aes.BlockSize = 128;
+			aes.Mode = CipherMode.CBC;
+			aes.Padding = PaddingMode.PKCS7;
+			return aes;
+		}
+
 		public static string Encrypt(string plainText, string passPhrase)
 		{
-			// Salt and IV is randomly generated each time, but is preprended to encrypted cipher text
-			// so that the same Salt and IV values can be used when decrypting.  
+			// Salt is randomly generated each time, but is preprended to encrypted cipher text
+			// so that the same Salt value can be used when decrypting.  
 			var saltStringBytes = Generate128BitsOfRandomEntropy();
-			//Console.WriteLine($"saltStringBytes: {Encoders.Hex.EncodeData(saltStringBytes)}");
-			//var ivStringBytes = Generate128BitsOfRandomEntropy();
-			//Console.WriteLine($"ivStringBytes: {Encoders.Hex.EncodeData(ivStringBytes)}");
+
 			var plainTextBytes = Encoding.UTF8.GetBytes(plainText);
 			using (var password = new Rfc2898DeriveBytes(passPhrase, saltStringBytes, DerivationIterations))
 			{
 				var keyBytes = password.GetBytes(Keysize / 8);
-				using (var symmetricKey = new AesManaged())
+				using (var aes = CreateAES())
 				{
-					symmetricKey.GenerateIV();
-					symmetricKey.BlockSize = 128;
-					symmetricKey.Mode = CipherMode.CBC;
-					symmetricKey.Padding = PaddingMode.PKCS7;
-					using (var encryptor = symmetricKey.CreateEncryptor(keyBytes, symmetricKey.IV))
+					aes.GenerateIV();
+					using (var encryptor = aes.CreateEncryptor(keyBytes, aes.IV))
 					{
 						using (var memoryStream = new MemoryStream())
 						{
+							memoryStream.Write(saltStringBytes, 0, saltStringBytes.Length);
+							memoryStream.Write(aes.IV, 0, aes.IV.Length);
 							using (var cryptoStream = new CryptoStream(memoryStream, encryptor, CryptoStreamMode.Write))
 							{
 								cryptoStream.Write(plainTextBytes, 0, plainTextBytes.Length);
 								cryptoStream.FlushFinalBlock();
-								// Create the final bytes as a concatenation of the random salt bytes, the random iv bytes and the cipher bytes.
-								var cipherTextBytes = saltStringBytes;
-								cipherTextBytes = cipherTextBytes.Concat(symmetricKey.IV).ToArray();
-								cipherTextBytes = cipherTextBytes.Concat(memoryStream.ToArray()).ToArray();
-								memoryStream.Close();
 								cryptoStream.Close();
-								return Convert.ToBase64String(cipherTextBytes);
 							}
+							var cipherTextBytes = memoryStream.ToArray();
+							memoryStream.Close();
+							return Convert.ToBase64String(cipherTextBytes);
 						}
 					}
 				}
@@ -59,36 +62,30 @@ namespace MagicalCryptoWallet.Crypto
 
 		public static string Decrypt(string cipherText, string passPhrase)
 		{
-			// Get the complete stream of bytes that represent:
-			// [32 bytes of Salt] + [16 bytes of IV] + [n bytes of CipherText]
 			var cipherTextBytesWithSaltAndIv = Convert.FromBase64String(cipherText);
-			// Get the saltbytes by extracting the first 16 bytes from the supplied cipherText bytes.
-			var saltStringBytes = cipherTextBytesWithSaltAndIv.Take(Keysize / 8).ToArray();
-			// Get the IV bytes by extracting the next 16 bytes from the supplied cipherText bytes.
-			var ivStringBytes = cipherTextBytesWithSaltAndIv.Skip(Keysize / 8).Take(Keysize / 8).ToArray();
-			// Get the actual cipher text bytes by removing the first 64 bytes from the cipherText string.
-			var cipherTextBytes = cipherTextBytesWithSaltAndIv.Skip((Keysize / 8) * 2).Take(cipherTextBytesWithSaltAndIv.Length - ((Keysize / 8) * 2)).ToArray();
 
-			using (var password = new Rfc2898DeriveBytes(passPhrase, saltStringBytes, DerivationIterations))
+			using (var memoryStream = new MemoryStream(cipherTextBytesWithSaltAndIv))
 			{
-				var keyBytes = password.GetBytes(Keysize / 8);
-				using (var symmetricKey = new AesManaged())
+				using (var reader = new BinaryReader(memoryStream))
 				{
-					symmetricKey.IV = ivStringBytes;
-					symmetricKey.BlockSize = 128;
-					symmetricKey.Mode = CipherMode.CBC;
-					symmetricKey.Padding = PaddingMode.PKCS7;
-					using (var decryptor = symmetricKey.CreateDecryptor(keyBytes, ivStringBytes))
+					var saltStringBytes = reader.ReadBytes(Keysize / 8);
+
+					using (var password = new Rfc2898DeriveBytes(passPhrase, saltStringBytes, DerivationIterations))
 					{
-						using (var memoryStream = new MemoryStream(cipherTextBytes))
+						var keyBytes = password.GetBytes(Keysize / 8);
+						using (var aes = CreateAES())
 						{
-							using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
+							var ivStringBytes = reader.ReadBytes(Keysize / 8);
+							using (var decryptor = aes.CreateDecryptor(keyBytes, ivStringBytes))
 							{
-								var plainTextBytes = new byte[cipherTextBytes.Length];
-								var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
-								memoryStream.Close();
-								cryptoStream.Close();
-								return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+								using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
+								{
+									var plainTextBytes = new byte[memoryStream.Length - memoryStream.Position];
+									var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
+									memoryStream.Close();
+									cryptoStream.Close();
+									return Encoding.UTF8.GetString(plainTextBytes, 0, decryptedByteCount);
+								}
 							}
 						}
 					}
@@ -96,15 +93,6 @@ namespace MagicalCryptoWallet.Crypto
 			}
 		}
 
-		// private static int c = 0;
-		// private static byte[] Generate128BitsOfRandomEntropy()
-		// {
-		// 	var s = (c % 2 == 0) 
-		// 		? "ad8d01ed34fcd39e30d06dfa3e7dd9f5"
-		// 		: "054afcb1e13a0d258ae423ed2f535f3c";
-		// 	c++;
-		// 	return Encoders.Hex.DecodeData(s);
-		// }
 
 		private static byte[] Generate128BitsOfRandomEntropy()
 		{

--- a/MagicalCryptoWallet/Crypto/StringCipher.cs
+++ b/MagicalCryptoWallet/Crypto/StringCipher.cs
@@ -80,7 +80,7 @@ namespace MagicalCryptoWallet.Crypto
 			using (var memoryStream = new MemoryStream(cipherTextBytesWithSaltAndIv))
 			{
 				var cipherLength = 0;
-				using (var reader = new BinaryReader(memoryStream))
+				using (var reader = new BinaryReader(memoryStream, Encoding.UTF8, true))
 				{
 					var salt = reader.ReadBytes(Keysize / 8);
 					iv = reader.ReadBytes(Keysize / 8);
@@ -109,10 +109,10 @@ namespace MagicalCryptoWallet.Crypto
 				{
 					using (var decryptor = aes.CreateDecryptor(key, iv))
 					{
-						memoryStream.Seek(cipherLength, SeekOrigin.End);
+						memoryStream.Seek(-cipherLength, SeekOrigin.End);
 						using (var cryptoStream = new CryptoStream(memoryStream, decryptor, CryptoStreamMode.Read))
 						{
-							var plainTextBytes = new byte[memoryStream.Length - memoryStream.Position];
+							var plainTextBytes = new byte[cipherLength];
 							var decryptedByteCount = cryptoStream.Read(plainTextBytes, 0, plainTextBytes.Length);
 							memoryStream.Close();
 							cryptoStream.Close();


### PR DESCRIPTION
This PR is to ensure that an cipherText could be decrypted with a wrong password failing silently. It achives that using authentication code (HMAC-SHA256 in this case). Additionally it uses AES instead of Rijndael because that's what [Microsoft recommends in their documentation site](https://msdn.microsoft.com/en-us/library/system.security.cryptography.rijndael(v=vs.110).aspx):

> **Remarks**
The Rijndael class is the predecessor of the Aes algorithm. **You should use the Aes algorithm instead of Rijndael**. For more information, see the entry The Differences Between Rijndael and AES in the .NET Security blog. 

