### PR TITLE
Fix for the FilterModel filters serialization

### DIFF
--- a/MagicalCryptoWallet/Backend/Models/FilterModel.cs
+++ b/MagicalCryptoWallet/Backend/Models/FilterModel.cs
@@ -23,6 +23,8 @@ namespace MagicalCryptoWallet.Backend.Models
 				builder.Append(":");
 				builder.Append(Filter.N);
 				builder.Append(":");
+				builder.Append(Filter.Data.Length);
+				builder.Append(":");
 				builder.Append(ByteHelpers.ToHex(Filter.Data.ToByteArray()));
 			}
 
@@ -46,7 +48,9 @@ namespace MagicalCryptoWallet.Backend.Models
 			else
 			{
 				var n = int.Parse(parts[1]);
-				var fba = new FastBitArray(ByteHelpers.FromHex(parts[2]));
+				var fba = new FastBitArray(ByteHelpers.FromHex(parts[3]));
+				fba.Length = int.Parse(parts[2]);
+
 				var filter = new GolombRiceFilter(fba, n);
 
 				return new FilterModel


### PR DESCRIPTION
Fix for the FilterModel class which didn't save the FastBitArray.Length property value. When the length value is not provided, it is assumed to be `len = (8 * n)` what is almost never the case. Filters doesn't work propertly with incorrect bitarray len value 