### PR TITLE
Synchronization Perfortmance Improvement 

### DIFF
--- a/MagicalCryptoWallet/Helpers/ByteHelpers.cs
+++ b/MagicalCryptoWallet/Helpers/ByteHelpers.cs
@@ -110,5 +110,20 @@ namespace System
 
 			return bytes;
 		}
+
+		public static byte[] SafeSubarray(this byte[] array, int offset, int count)
+		{
+			if(array == null)
+				throw new ArgumentNullException("array");
+			if(offset < 0 || offset > array.Length)
+				throw new ArgumentOutOfRangeException("offset");
+			if(count < 0 || offset + count > array.Length)
+				throw new ArgumentOutOfRangeException("count");
+			if(offset == 0 && array.Length == count)
+				return array;
+			var data = new byte[count];
+			Buffer.BlockCopy(array, offset, data, 0, count);
+			return data;
+		}		
 	}
 }


### PR DESCRIPTION
This PR is for issue #41 (Make Golomb-Rice filtering PR initial indexing faster). It achieves the performance gain batching RPC `GetBlockAsync` requests and avoiding opening and closing the p2wpkh uxtos and index files. If it is not desirable to keep the files opened for a long time, we can aupdate them on batches too (this is not done).

In my machine with a partially synchronized testnet blockchain this change is about 3X faster. 