### PR TITLE
Add test for chain reogs

### DIFF
--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -360,11 +360,11 @@ namespace MagicalCryptoWallet.Tests
 				times = 0;
 				while ((filterCount = downloader.GetFiltersIncluding(new Height(0)).Count()) < 120)
 				{
-					if (times > 240) // 2 min
+					if (times > 240) // 4 min
 					{
 						throw new TimeoutException($"{nameof(IndexDownloader)} test timed out. Needed filters: {120}, got only: {filterCount}.");
 					}
-					await Task.Delay(500);
+					await Task.Delay(1000);
 					times++;
 				}
 

--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -330,7 +330,7 @@ namespace MagicalCryptoWallet.Tests
 		{			
 			await AssertFiltersInitializedAsync();
 
-			var node0 = Fixture.BackendRegTestNode;
+			var node = Fixture.BackendRegTestNode;
 			var indexFilePath = Path.Combine(SharedFixture.DataDir, nameof(FilterDownloaderTestAsync), $"Index{Global.RpcClient.Network}.dat");
 
 			var downloader = new IndexDownloader(Global.RpcClient.Network, indexFilePath, new Uri(Fixture.BackendEndPoint));
@@ -353,16 +353,16 @@ namespace MagicalCryptoWallet.Tests
 				}
 
 				// Test syncronization after fork.
-				var node1 = Fixture.BackendNodeBuilder.CreateNode(start: true);
-				await node1.CreateRPCClient().GenerateAsync(120);
-				await node1.SyncAsync(node0);
+				var tip = await Global.RpcClient.GetBestBlockHashAsync();
+				await Global.RpcClient.InvalidateBlockAsync(tip);
+				await Global.RpcClient.GenerateAsync(5);
 
 				times = 0;
-				while ((filterCount = downloader.GetFiltersIncluding(new Height(0)).Count()) < 120)
+				while ((filterCount = downloader.GetFiltersIncluding(new Height(0)).Count()) < 116)
 				{
 					if (times > 240) // 4 min
 					{
-						throw new TimeoutException($"{nameof(IndexDownloader)} test timed out. Needed filters: {120}, got only: {filterCount}.");
+						throw new TimeoutException($"{nameof(IndexDownloader)} test timed out. Needed filters: {116}, got only: {filterCount}.");
 					}
 					await Task.Delay(1000);
 					times++;
@@ -370,7 +370,7 @@ namespace MagicalCryptoWallet.Tests
 
 				// Test filter block hashes are correct after fork.
 				var filters = downloader.GetFiltersIncluding(Network.RegTest.GenesisHash).ToArray();
-				for (int i = 0; i < 120; i++)
+				for (int i = 0; i < 116; i++)
 				{
 					var expectedHash = await Global.RpcClient.GetBlockHashAsync(i);
 					var filter = filters[i];

--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -323,6 +323,68 @@ namespace MagicalCryptoWallet.Tests
 			}
 		}
 
+
+
+		[Fact]
+		public async Task FilterReorgTestAsync()
+		{			
+			await AssertFiltersInitializedAsync();
+
+			var node0 = Fixture.BackendRegTestNode;
+			var indexFilePath = Path.Combine(SharedFixture.DataDir, nameof(FilterDownloaderTestAsync), $"Index{Global.RpcClient.Network}.dat");
+
+			var downloader = new IndexDownloader(Global.RpcClient.Network, indexFilePath, new Uri(Fixture.BackendEndPoint));
+			try
+			{
+				downloader.Syncronize(requestInterval: TimeSpan.FromSeconds(1));
+
+				// Test initial syncronization.
+				
+				var times = 0;
+				int filterCount;
+				while ((filterCount = downloader.GetFiltersIncluding(Network.RegTest.GenesisHash).Count()) < 102)
+				{
+					if (times > 500) // 30 sec
+					{
+						throw new TimeoutException($"{nameof(IndexDownloader)} test timed out. Needed filters: {102}, got only: {filterCount}.");
+					}
+					await Task.Delay(100);
+					times++;
+				}
+
+				// Test syncronization after fork.
+				var node1 = Fixture.BackendNodeBuilder.CreateNode(start: true);
+				await node1.CreateRPCClient().GenerateAsync(120);
+				await node1.SyncAsync(node0);
+
+				times = 0;
+				while ((filterCount = downloader.GetFiltersIncluding(new Height(0)).Count()) < 120)
+				{
+					if (times > 240) // 2 min
+					{
+						throw new TimeoutException($"{nameof(IndexDownloader)} test timed out. Needed filters: {120}, got only: {filterCount}.");
+					}
+					await Task.Delay(500);
+					times++;
+				}
+
+				// Test filter block hashes are correct after fork.
+				var filters = downloader.GetFiltersIncluding(Network.RegTest.GenesisHash).ToArray();
+				for (int i = 0; i < 120; i++)
+				{
+					var expectedHash = await Global.RpcClient.GetBlockHashAsync(i);
+					var filter = filters[i];
+					Assert.Equal(i, filter.BlockHeight.Value);
+					Assert.Equal(expectedHash, filter.BlockHash);
+					Assert.Null(filter.Filter);
+				}
+			}
+			finally
+			{
+				downloader.Stop();
+			}
+		}
+
 		#endregion
 
 		#region ClientTests

--- a/MagicalCryptoWallet/Extensions/RPCClientExtensions.cs
+++ b/MagicalCryptoWallet/Extensions/RPCClientExtensions.cs
@@ -34,6 +34,16 @@ namespace NBitcoin.RPC
 				Hash = uint256.Parse(resp.Result["hash"].ToString())
 			};
 		}
+
+		/// <summary>
+		/// Permanently marks a block as invalid, as if it violated a consensus rule.
+		/// </summary>
+		/// <param name="blockhash">the hash of the block to mark as invalid</param>
+		public static async Task InvalidateBlockAsync(this RPCClient rpc, uint256 blockhash)
+		{
+			await rpc.SendCommandAsync("invalidateblock", blockhash.ToString()).ConfigureAwait(false);
+			return;
+		}
 	}
 
 	public class BlockInfo


### PR DESCRIPTION
This PR for issue https://github.com/nopara73/MagicalCryptoWallet/issues/61. The test does the following:

1) Creates two nodes (Node0 and Node1)
2) Node0 generates 102 blocks
3) Backend creates the index for those 102 blocks
4) Node1 generates 120 blocks
5) Node0 and Node1 connects one each other and synchronize (to the longest chain)
6) Verify the filters have been created for the 120 blocks
