### PR TITLE
Test buildtransactionasync

### DIFF
--- a/MagicalCryptoWallet.Tests/NodeBuilding/CoreNode.cs
+++ b/MagicalCryptoWallet.Tests/NodeBuilding/CoreNode.cs
@@ -97,11 +97,11 @@ namespace MagicalCryptoWallet.Tests.NodeBuilding
 
 		public Node CreateNodeClient()
 		{
-			return Node.Connect(Network.RegTest, "127.0.0.1:" + _ports[0]);
+			return Node.Connect(Network.RegTest, new IPEndPoint(IPAddress.Loopback,_ports[0]));
 		}
 		public Node CreateNodeClient(NodeConnectionParameters parameters)
 		{
-			return Node.Connect(Network.RegTest, "127.0.0.1:" + _ports[0], parameters);
+			return Node.Connect(Network.RegTest, new IPEndPoint(IPAddress.Loopback,_ports[0]), parameters);
 		}
 
 		public async Task StartAsync()

--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -669,7 +669,7 @@ namespace MagicalCryptoWallet.Tests
 				}
 
 				var scp = new Key().ScriptPubKey;
-				var res2 = await wallet.BuildTransactionAsync("password", new[] { (scp, new Money(0.05m, MoneyUnit.BTC), "foo") }, 5, false);
+				var res2 = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(scp, new Money(0.05m, MoneyUnit.BTC), "foo") }, 5, false);
 
 				Assert.NotNull(res2.Transaction);
 				Assert.Single(res2.OuterWalletOutputs);
@@ -690,7 +690,7 @@ namespace MagicalCryptoWallet.Tests
 
 				Script receive = wallet.GetReceiveKey("Basic").GetP2wpkhScript();
 				Money amountToSend = wallet.Coins.Where(x => x.Unspent).Sum(x => x.Amount) / 2;
-				var res = await wallet.BuildTransactionAsync("password", new[] { (receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true);
+				var res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -730,7 +730,7 @@ namespace MagicalCryptoWallet.Tests
 				
 				receive = wallet.GetReceiveKey("SubtractFeeFromAmount").GetP2wpkhScript();
 				amountToSend = wallet.Coins.Where(x => x.Unspent).Sum(x => x.Amount) / 2;
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true, subtractFeeFromAmountIndex: 0);
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true, subtractFeeFromAmountIndex: 0);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -763,7 +763,7 @@ namespace MagicalCryptoWallet.Tests
 
 				#region LowFee
 
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true);
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, amountToSend, "foo") }, 1008, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -796,7 +796,7 @@ namespace MagicalCryptoWallet.Tests
 
 				#region MediumFee
 
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, amountToSend, "foo") }, 144, allowUnconfirmed: true);
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, amountToSend, "foo") }, 144, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -829,7 +829,7 @@ namespace MagicalCryptoWallet.Tests
 
 				#region HighFee
 
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, amountToSend, "foo") }, 2, allowUnconfirmed: true);
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, amountToSend, "foo") }, 2, allowUnconfirmed: true);
 
 				Assert.Equal(2, res.InnerWalletOutputs.Count());
 				Assert.Empty(res.OuterWalletOutputs);
@@ -868,7 +868,7 @@ namespace MagicalCryptoWallet.Tests
 				#region MaxAmount
 
 				receive = wallet.GetReceiveKey("MaxAmount").GetP2wpkhScript();
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, Money.Zero, "foo") }, 1008, allowUnconfirmed: true);
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, Money.Zero, "foo") }, 1008, allowUnconfirmed: true);
 
 				Assert.Single(res.InnerWalletOutputs);
 				Assert.Empty(res.OuterWalletOutputs);
@@ -896,7 +896,7 @@ namespace MagicalCryptoWallet.Tests
 				receive = wallet.GetReceiveKey("InputSelection").GetP2wpkhScript();
 
 				var inputCountBefore = res.SpentCoins.Count();
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, Money.Zero, "foo") }, 1008,
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, Money.Zero, "foo") }, 1008,
 					allowUnconfirmed: true,
 					allowedInputs: wallet.Coins.Where(x=>x.Unspent).Select(x=>new TxoRef(x.TransactionId, x.Index)).Take(1));
 
@@ -916,7 +916,7 @@ namespace MagicalCryptoWallet.Tests
 
 				Assert.Single(res.Transaction.Transaction.Outputs);
 
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, Money.Zero, "foo") }, 1008, 
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, Money.Zero, "foo") }, 1008, 
 					allowUnconfirmed: true,
 					allowedInputs: new[] { res.SpentCoins.Select(x => new TxoRef(x.TransactionId, x.Index)).First() });
 
@@ -932,7 +932,7 @@ namespace MagicalCryptoWallet.Tests
 
 				#region Labeling
 
-				res = await wallet.BuildTransactionAsync("password", new[] { (receive, Money.Zero, "my label") }, 1008,
+				res = await wallet.BuildTransactionAsync("password", new[] { new WalletService.Operation(receive, Money.Zero, "my label") }, 1008,
 					allowUnconfirmed: true);
 
 				Assert.Single(res.InnerWalletOutputs);
@@ -940,8 +940,8 @@ namespace MagicalCryptoWallet.Tests
 
 				amountToSend = wallet.Coins.Where(x => x.Unspent).Sum(x => x.Amount) / 3;
 				res = await wallet.BuildTransactionAsync("password", new[] {
-					(new Key().ScriptPubKey, amountToSend, "outgoing"),
-					(new Key().ScriptPubKey, amountToSend, "outgoing2")
+					new WalletService.Operation(new Key().ScriptPubKey, amountToSend, "outgoing"),
+					new WalletService.Operation(new Key().ScriptPubKey, amountToSend, "outgoing2")
 				}, 1008,
 					allowUnconfirmed: true);
 
@@ -979,6 +979,46 @@ namespace MagicalCryptoWallet.Tests
 			}
 		}
 
+		[Fact]
+		public async Task BuildTransactionValidationsTest()
+		{
+			// Make sure fitlers are created on the server side.
+			await AssertFiltersInitializedAsync();
+
+			var network = Global.RpcClient.Network;
+
+			// Create the services.
+			// 1. Create connection service.
+			var nodes = new NodesGroup(Global.Config.Network,
+					requirements: new NodeRequirement
+					{
+						RequiredServices = NodeServices.Network,
+						MinVersion = ProtocolVersion.WITNESS_VERSION
+					});
+			nodes.ConnectedNodes.Add(RegTestFixture.BackendRegTestNode.CreateNodeClient());
+			
+			// 2. Create mempool service.
+			var memPoolService = new MemPoolService();
+			Node node = RegTestFixture.BackendRegTestNode.CreateNodeClient();
+			node.Behaviors.Add(new MemPoolBehavior(memPoolService));
+
+			// 3. Create index downloader service.
+			var indexFilePath = Path.Combine(SharedFixture.DataDir, nameof(SendTestsFromHiddenWalletAsync), $"Index{Global.RpcClient.Network}.dat");
+			var indexDownloader = new IndexDownloader(Global.RpcClient.Network, indexFilePath, new Uri(RegTestFixture.BackendEndPoint));
+
+			// 4. Create key manager service.
+			var keyManager = KeyManager.CreateNew(out Mnemonic mnemonic, "password");
+			
+			// 5. Create wallet service.
+			var blocksFolderPath = Path.Combine(SharedFixture.DataDir, nameof(SendTestsFromHiddenWalletAsync), $"Blocks");
+			var wallet = new WalletService(keyManager, indexDownloader, memPoolService, nodes, blocksFolderPath);
+			wallet.NewFilterProcessed += Wallet_NewFilterProcessed;
+
+			var scp = new Key().ScriptPubKey;
+			await Assert.ThrowsAsync<ArgumentNullException>( async ()=> await wallet.BuildTransactionAsync(null, null, 0) );
+			await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, new[]{ (WalletService.Operation)null }, 0) );
+			await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, new WalletService.Operation[0], 0) );
+		}
 		#endregion
 	}
 }

--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -1083,6 +1083,12 @@ namespace MagicalCryptoWallet.Tests
 					await wallet.InitializeAsync(cts.Token); // Initialize wallet service.
 				}
 
+				// subtract Fee from amount index with no enough money 
+				operations = new[]{ 
+					new WalletService.Operation(scp,  Money.Satoshis(1m)),
+					new WalletService.Operation(scp, Money.Coins(0.5m)) };
+				await Assert.ThrowsAsync<InsufficientBalanceException>( async ()=> await wallet.BuildTransactionAsync("password", operations, 2, false, 0) );
+
 				// No enough money (only one confirmed coin, no unconfirmed allowed)
 				operations = new[]{ new WalletService.Operation(scp, Money.Coins(1.5m)) };
 				await Assert.ThrowsAsync<InsufficientBalanceException>( async ()=> await wallet.BuildTransactionAsync(null, operations, 2) );
@@ -1113,7 +1119,7 @@ namespace MagicalCryptoWallet.Tests
 				await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, operations, 2, false, null, Script.Empty) );
 
 				operations = new[]{ new WalletService.Operation(scp, Money.Coins(0.5m)) };
-				var btx =  await wallet.BuildTransactionAsync("password", operations, 2);
+				btx =  await wallet.BuildTransactionAsync("password", operations, 2);
 				
 				operations = new[]{ new WalletService.Operation(scp, Money.Coins(0.00005m)) };
 				btx =  await wallet.BuildTransactionAsync("password", operations, 2, false, 0);
@@ -1121,9 +1127,6 @@ namespace MagicalCryptoWallet.Tests
 				Assert.Equal( 1, btx.SpentCoins.Count() );
 				Assert.Equal( txid, btx.SpentCoins.First().TransactionId );
 				Assert.Equal( false, btx.Transaction.Transaction.RBF ); // Is this okay
-
-
-
 			}
 			finally
 			{

--- a/MagicalCryptoWallet.Tests/RegTests.cs
+++ b/MagicalCryptoWallet.Tests/RegTests.cs
@@ -1044,12 +1044,22 @@ namespace MagicalCryptoWallet.Tests
 			// toSend amount sum has to be in range 0 to 2099999997690000
 			await Assert.ThrowsAsync<ArgumentOutOfRangeException>( async ()=> await wallet.BuildTransactionAsync(null, invalidOperationList, 2) );
 
+			// toSend negative sum amount
+			var operations = new[]{ 
+				new WalletService.Operation(scp, -10000) };
+			await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, operations, 2) );
+
+			// toSend negative operation amount
+			operations = new[]{ 
+				new WalletService.Operation(scp,  20000),
+				new WalletService.Operation(scp, -10000) };
+			await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, operations, 2) );
+
 			// toSend ammount sum has to be less than ulong.MaxValue
 			await Assert.ThrowsAsync<OverflowException>( async ()=> await wallet.BuildTransactionAsync(null, overflowOperationList, 2) );
 
 			// allowedInputs cannot be empty
 			await Assert.ThrowsAsync<ArgumentException>( async ()=> await wallet.BuildTransactionAsync(null, validOperationList, 2, false, null, null, new TxoRef[0]) );
-
 
 			// Get some money, make it confirm.
 			var key = wallet.GetReceiveKey("foo label");

--- a/MagicalCryptoWallet/Extensions/TorHttpClientExtensions.cs
+++ b/MagicalCryptoWallet/Extensions/TorHttpClientExtensions.cs
@@ -1,0 +1,23 @@
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using MagicalCryptoWallet.TorSocks5;
+
+public static class TorHttpClientExtensions
+{
+    public static async Task<HttpResponseMessage> SendAndRetryAsync(this TorHttpClient client, HttpMethod method, string relativeUri, int retry = 2, HttpContent content = null)
+    {
+        HttpResponseMessage response = null;
+        while(retry-- > 0)
+        {
+            response = await client.SendAsync(method, relativeUri, content);
+            if(response.IsSuccessStatusCode)
+            {
+                break;
+            }
+            await Task.Delay(1000);
+
+        }
+        return response;
+    }
+}

--- a/MagicalCryptoWallet/Services/WalletService.cs
+++ b/MagicalCryptoWallet/Services/WalletService.cs
@@ -468,6 +468,13 @@ namespace MagicalCryptoWallet.Services
 			{
 				throw new ArgumentException($"All {nameof(toSend)} element must be not null.");
 			}
+
+			var sum = toSend.Sum(x => x.Amount);
+			if(sum < 0 || sum > 2099999997690000)
+			{
+				throw new ArgumentOutOfRangeException($"{nameof(toSend)} sum cannot be smaller than 0 or greater than 2099999997690000.");
+			}
+			
 			int spendAllCount = toSend.Count(x => x.Amount == Money.Zero);
 			if (spendAllCount > 1)
 			{
@@ -500,7 +507,7 @@ namespace MagicalCryptoWallet.Services
 			{
 				if(!allowedInputs.Any())
 				{
-					throw new NotSupportedException($"{nameof(allowedInputs)} is not null, but empty.");
+					throw new ArgumentException($"{nameof(allowedInputs)} is not null, but empty.");
 				}
 
 				if (allowUnconfirmed)

--- a/MagicalCryptoWallet/Services/WalletService.cs
+++ b/MagicalCryptoWallet/Services/WalletService.cs
@@ -468,6 +468,10 @@ namespace MagicalCryptoWallet.Services
 			{
 				throw new ArgumentException($"All {nameof(toSend)} element must be not null.");
 			}
+			if(toSend.Any(x=>x.Amount < Money.Zero ))
+			{
+				throw new ArgumentException($"All {nameof(toSend)} element must be greater or equal to zero.");
+			}
 
 			var sum = toSend.Sum(x => x.Amount);
 			if(sum < 0 || sum > 2099999997690000)

--- a/MagicalCryptoWallet/Services/WalletService.cs
+++ b/MagicalCryptoWallet/Services/WalletService.cs
@@ -462,7 +462,7 @@ namespace MagicalCryptoWallet.Services
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
 		public async Task<BuildTransactionResult> BuildTransactionAsync(string password, Operation[] toSend, int feeTarget, bool allowUnconfirmed = false, int? subtractFeeFromAmountIndex = null, Script customChange = null, IEnumerable<TxoRef> allowedInputs = null)
 		{
-			password = Guard.Correct(password);
+			password = password ?? ""; // Correction.
 			toSend = Guard.NotNullOrEmpty(nameof(toSend), toSend);
 			if(toSend.Any(x=>x==null))
 			{


### PR DESCRIPTION
This PR contains an unit test for validating the `BuildTransactionAsync` method works propertly with several combination of arguments. In order to reduce the amount of possible combinations, I introduced a type for replacing tuples in parameter list.